### PR TITLE
Add journey_instance_uuid UUID col to journey_instances

### DIFF
--- a/guided-match/ddl.sql
+++ b/guided-match/ddl.sql
@@ -31,6 +31,7 @@ CREATE INDEX JOIQ_IDX1 on JOURNEY_INSTANCE_QUESTIONS (journey_question_id);
 
 CREATE TABLE journey_instances (
   journey_instance_id               BIGSERIAL PRIMARY KEY,
+  journey_instance_uuid             UUID NOT NULL UNIQUE,
   journey_id                        UUID NOT NULL,
   journey_start_date                DATE NOT NULL,
   journey_end_date                  DATE


### PR DESCRIPTION
The [GM API](https://github.com/Crown-Commercial-Service/ccs-scale-api-definitions/blob/master/guided-match/guided-match-service.yaml#L134) specifies the 'session' identifier `journeyInstanceId` to be a UUID.  This PR adds a new UUID column to `journey_instances` with unique constraint applied. This value will be generated by the application for each new GM session then used throughout the journey.  This is preferable to exposing internal database IDs via the API but keeps the use of the auto-increment value for the PK and related FKs.