### PR TITLE
Add missing search_id FK to journey_instances

### DIFF
--- a/guided-match/ddl.sql
+++ b/guided-match/ddl.sql
@@ -33,7 +33,7 @@ CREATE TABLE journey_instances (
   journey_instance_id               BIGSERIAL PRIMARY KEY,
   journey_instance_uuid             UUID NOT NULL UNIQUE,
   journey_id                        UUID NOT NULL,
-  search_id                         INTEGER NOT NULL,
+  original_search_term              VARCHAR(200) NOT NULL,
   journey_start_date                DATE NOT NULL,
   journey_end_date                  DATE
 );
@@ -89,7 +89,3 @@ ADD CONSTRAINT journey_instance_answers_journey_instance_questions_fk FOREIGN KE
 ALTER TABLE journey_instances
 ADD CONSTRAINT journey_instances_journey_fk FOREIGN KEY (journey_id)
     REFERENCES journeys(journey_id);
-
-ALTER TABLE journey_instances
-ADD CONSTRAINT journey_instances_search_terms_fk FOREIGN KEY (search_id)
-    REFERENCES search_terms(search_id);

--- a/guided-match/ddl.sql
+++ b/guided-match/ddl.sql
@@ -24,7 +24,9 @@ CREATE TABLE journey_instance_questions (
   journey_instance_id               BIGINT NOT NULL,
   journey_question_id               UUID NOT NULL,
   question_order                    SMALLINT NOT NULL,
-  question_text                     VARCHAR(2000) NOT NULL
+  question_text                     VARCHAR(500) NOT NULL,
+  question_hint                     VARCHAR(500) NOT NULL,
+  question_type                     VARCHAR(50) NOT NULL
 );
 CREATE INDEX JOIQ_IDX1 on JOURNEY_INSTANCE_QUESTIONS (journey_question_id);
 

--- a/guided-match/ddl.sql
+++ b/guided-match/ddl.sql
@@ -33,6 +33,7 @@ CREATE TABLE journey_instances (
   journey_instance_id               BIGSERIAL PRIMARY KEY,
   journey_instance_uuid             UUID NOT NULL UNIQUE,
   journey_id                        UUID NOT NULL,
+  search_id                         INTEGER NOT NULL,
   journey_start_date                DATE NOT NULL,
   journey_end_date                  DATE
 );
@@ -51,7 +52,7 @@ CREATE INDEX JOUR_IDX2 on JOURNEYS(parent_journey_id);
 CREATE TABLE search_domains (
   domain_modifier_id               SERIAL PRIMARY KEY,
   search_id                        INTEGER NOT NULL,
-  journey_id                       UUID NOT NULL,          
+  journey_id                       UUID NOT NULL,
   modifier_journey_name            VARCHAR(20) NOT NULL UNIQUE,
   journey_selection_text           VARCHAR(200) NOT NULL,
   journey_selection_description   VARCHAR(2000)
@@ -88,3 +89,7 @@ ADD CONSTRAINT journey_instance_answers_journey_instance_questions_fk FOREIGN KE
 ALTER TABLE journey_instances
 ADD CONSTRAINT journey_instances_journey_fk FOREIGN KEY (journey_id)
     REFERENCES journeys(journey_id);
+
+ALTER TABLE journey_instances
+ADD CONSTRAINT journey_instances_search_terms_fk FOREIGN KEY (search_id)
+    REFERENCES search_terms(search_id);


### PR DESCRIPTION
API requires the search term to be stored in the journey instance 👍 