### PR TITLE
Add missing lookup entry UUID col to search domains plus sample data

### DIFF
--- a/guided-match/ddl.sql
+++ b/guided-match/ddl.sql
@@ -53,6 +53,7 @@ CREATE INDEX JOUR_IDX2 on JOURNEYS(parent_journey_id);
 
 CREATE TABLE search_domains (
   domain_modifier_id               SERIAL PRIMARY KEY,
+  lookup_entry_id                  UUID NOT NULL DEFAULT uuid_generate_v4(),
   search_id                        INTEGER NOT NULL,
   journey_id                       UUID NOT NULL,
   modifier_journey_name            VARCHAR(20) NOT NULL UNIQUE,

--- a/guided-match/ddl.sql
+++ b/guided-match/ddl.sql
@@ -6,6 +6,7 @@ Description This file is a script to create the tables for the Find a Thing data
             for the graph database.
 
 */
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 
 CREATE TABLE journey_instance_answers (
   journey_instance_answer_id        BIGSERIAL PRIMARY KEY,

--- a/guided-match/insert.sql
+++ b/guided-match/insert.sql
@@ -14,22 +14,22 @@ VALUES ('b87a0636-654e-11ea-bc55-0242ac130003', 'Linen & Laundry', true),
 INSERT INTO "search_terms" (search_term)
 VALUES ('linen'),('laundry services'),('legal'),('laptops');
 
-INSERT INTO search_domains (search_id, journey_id, modifier_journey_name, journey_selection_text, journey_selection_description)
-SELECT search_id, 'b87a0636-654e-11ea-bc55-0242ac130003', 'hospitals', 'L&L hospital journey', 'Linen & Laundry hospital specific GM journey'
+INSERT INTO search_domains (search_id, journey_id, modifier_journey_name, journey_selection_text, journey_selection_description, lookup_entry_id)
+SELECT search_id, 'b87a0636-654e-11ea-bc55-0242ac130003', 'hospitals', 'L&L hospital journey', 'Linen & Laundry hospital specific GM journey', 'a3a9783f-3ccd-4bb9-ae9b-63d6ea62e440'
 FROM search_terms
 WHERE search_term = 'linen';
 
-INSERT INTO search_domains (search_id, journey_id, modifier_journey_name, journey_selection_text, journey_selection_description)
-SELECT search_id, 'b87a0636-654e-11ea-bc55-0242ac130003', 'bedsheets', 'L&L bedsheets journey', 'Linen & Laundry bedsheets specific GM journey'
+INSERT INTO search_domains (search_id, journey_id, modifier_journey_name, journey_selection_text, journey_selection_description, lookup_entry_id)
+SELECT search_id, 'b87a0636-654e-11ea-bc55-0242ac130003', 'bedsheets', 'L&L bedsheets journey', 'Linen & Laundry bedsheets specific GM journey', 'ef55cae4-df47-466a-aef1-45a5d2008e02'
 FROM search_terms
 WHERE search_term = 'laundry services';
 
-INSERT INTO search_domains (search_id, journey_id, modifier_journey_name, journey_selection_text, journey_selection_description)
-SELECT search_id, 'ccb5c730-75b5-11ea-bc55-0242ac130003', 'contracts', 'Legal Services contracts journey', 'WPS Legal Services contracts specific journey'
+INSERT INTO search_domains (search_id, journey_id, modifier_journey_name, journey_selection_text, journey_selection_description, lookup_entry_id)
+SELECT search_id, 'ccb5c730-75b5-11ea-bc55-0242ac130003', 'contracts', 'Legal Services contracts journey', 'WPS Legal Services contracts specific journey', 'e667b2b5-ab4d-4949-ac35-2eb4e5754992'
 FROM search_terms
 WHERE search_term = 'legal';
 
-INSERT INTO search_domains (search_id, journey_id, modifier_journey_name, journey_selection_text, journey_selection_description)
-SELECT search_id, 'ccb6174e-75b5-11ea-bc55-0242ac130003', 'conveyancing', 'Legal Services conveyancing journey', 'WPS Legal Services conveyancing specific journey'
+INSERT INTO search_domains (search_id, journey_id, modifier_journey_name, journey_selection_text, journey_selection_description, lookup_entry_id)
+SELECT search_id, 'ccb6174e-75b5-11ea-bc55-0242ac130003', 'conveyancing', 'Legal Services conveyancing journey', 'WPS Legal Services conveyancing specific journey', 'c3360661-f3b5-4c78-bf37-a7f32bfb449f'
 FROM search_terms
 WHERE search_term = 'laptops';

--- a/guided-match/insert.sql
+++ b/guided-match/insert.sql
@@ -7,7 +7,7 @@ DELETE FROM search_terms;
 DELETE FROM journeys;
 
 INSERT INTO journeys (journey_id, journey_name, published)
-VALUES ('ccb5a43a-75b5-11ea-bc55-0242ac130003', 'Linen & Laundry', true),
+VALUES ('b87a0636-654e-11ea-bc55-0242ac130003', 'Linen & Laundry', true),
 ('ccb5c730-75b5-11ea-bc55-0242ac130003', 'Wider Public Sector Legal Services', true),
 ('ccb6174e-75b5-11ea-bc55-0242ac130003', 'Tech & EduTech', true);
 
@@ -15,12 +15,12 @@ INSERT INTO "search_terms" (search_term)
 VALUES ('linen'),('laundry services'),('legal'),('laptops');
 
 INSERT INTO search_domains (search_id, journey_id)
-SELECT search_id, 'ccb5a43a-75b5-11ea-bc55-0242ac130003'
+SELECT search_id, 'b87a0636-654e-11ea-bc55-0242ac130003'
 FROM search_terms
 WHERE search_term = 'linen';
 
 INSERT INTO search_domains (search_id, journey_id)
-SELECT search_id, 'ccb5a43a-75b5-11ea-bc55-0242ac130003'
+SELECT search_id, 'b87a0636-654e-11ea-bc55-0242ac130003'
 FROM search_terms
 WHERE search_term = 'laundry services';
 

--- a/guided-match/insert.sql
+++ b/guided-match/insert.sql
@@ -1,0 +1,35 @@
+/*
+* Create some basic search term - domain - journey data and relationships for test/development
+*/
+
+DELETE FROM search_domains;
+DELETE FROM search_terms;
+DELETE FROM journeys;
+
+INSERT INTO journeys (journey_id, journey_name)
+VALUES ('ccb5a43a-75b5-11ea-bc55-0242ac130003', 'Linen & Laundry'),
+('ccb5c730-75b5-11ea-bc55-0242ac130003', 'Wider Public Sector Legal Services'),
+('ccb6174e-75b5-11ea-bc55-0242ac130003', 'Tech & EduTech');
+
+INSERT INTO "search_terms" (search_term)
+VALUES ('linen'),('laundry services'),('legal'),('laptops');
+
+INSERT INTO search_domains (search_id, journey_id)
+SELECT search_id, 'ccb5a43a-75b5-11ea-bc55-0242ac130003'
+FROM search_terms
+WHERE search_term = 'linen';
+
+INSERT INTO search_domains (search_id, journey_id)
+SELECT search_id, 'ccb5a43a-75b5-11ea-bc55-0242ac130003'
+FROM search_terms
+WHERE search_term = 'laundry services';
+
+INSERT INTO search_domains (search_id, journey_id)
+SELECT search_id, 'ccb5c730-75b5-11ea-bc55-0242ac130003'
+FROM search_terms
+WHERE search_term = 'legal';
+
+INSERT INTO search_domains (search_id, journey_id)
+SELECT search_id, 'ccb6174e-75b5-11ea-bc55-0242ac130003'
+FROM search_terms
+WHERE search_term = 'laptops';

--- a/guided-match/insert.sql
+++ b/guided-match/insert.sql
@@ -15,21 +15,21 @@ INSERT INTO "search_terms" (search_term)
 VALUES ('linen'),('laundry services'),('legal'),('laptops');
 
 INSERT INTO search_domains (search_id, journey_id, modifier_journey_name, journey_selection_text, journey_selection_description, lookup_entry_id)
-SELECT search_id, 'b87a0636-654e-11ea-bc55-0242ac130003', 'hospitals', 'L&L hospital journey', 'Linen & Laundry hospital specific GM journey', 'a3a9783f-3ccd-4bb9-ae9b-63d6ea62e440'
+SELECT search_id, 'b87a0636-654e-11ea-bc55-0242ac130003', 'hospitals', 'Linen & Laundry hospitals', 'Linen & Laundry hospital specific guided match', 'a3a9783f-3ccd-4bb9-ae9b-63d6ea62e440'
 FROM search_terms
 WHERE search_term = 'linen';
 
 INSERT INTO search_domains (search_id, journey_id, modifier_journey_name, journey_selection_text, journey_selection_description, lookup_entry_id)
-SELECT search_id, 'b87a0636-654e-11ea-bc55-0242ac130003', 'bedsheets', 'L&L bedsheets journey', 'Linen & Laundry bedsheets specific GM journey', 'ef55cae4-df47-466a-aef1-45a5d2008e02'
+SELECT search_id, 'b87a0636-654e-11ea-bc55-0242ac130003', 'bedsheets', 'Linen & Laundry bedsheets', 'Linen & Laundry bedsheets specific guided match', 'ef55cae4-df47-466a-aef1-45a5d2008e02'
 FROM search_terms
 WHERE search_term = 'laundry services';
 
 INSERT INTO search_domains (search_id, journey_id, modifier_journey_name, journey_selection_text, journey_selection_description, lookup_entry_id)
-SELECT search_id, 'ccb5c730-75b5-11ea-bc55-0242ac130003', 'contracts', 'Legal Services contracts journey', 'WPS Legal Services contracts specific journey', 'e667b2b5-ab4d-4949-ac35-2eb4e5754992'
+SELECT search_id, 'ccb5c730-75b5-11ea-bc55-0242ac130003', 'contracts', 'Legal Services contracts', 'WPS Legal Services contracts specific guided match', 'e667b2b5-ab4d-4949-ac35-2eb4e5754992'
 FROM search_terms
 WHERE search_term = 'legal';
 
 INSERT INTO search_domains (search_id, journey_id, modifier_journey_name, journey_selection_text, journey_selection_description, lookup_entry_id)
-SELECT search_id, 'ccb6174e-75b5-11ea-bc55-0242ac130003', 'conveyancing', 'Legal Services conveyancing journey', 'WPS Legal Services conveyancing specific journey', 'c3360661-f3b5-4c78-bf37-a7f32bfb449f'
+SELECT search_id, 'ccb6174e-75b5-11ea-bc55-0242ac130003', 'computer hardware', 'Tech/EduTech computer hardware', 'Tech/EduTech computer hardware specific guided match', 'c3360661-f3b5-4c78-bf37-a7f32bfb449f'
 FROM search_terms
 WHERE search_term = 'laptops';

--- a/guided-match/insert.sql
+++ b/guided-match/insert.sql
@@ -14,22 +14,22 @@ VALUES ('b87a0636-654e-11ea-bc55-0242ac130003', 'Linen & Laundry', true),
 INSERT INTO "search_terms" (search_term)
 VALUES ('linen'),('laundry services'),('legal'),('laptops');
 
-INSERT INTO search_domains (search_id, journey_id)
-SELECT search_id, 'b87a0636-654e-11ea-bc55-0242ac130003'
+INSERT INTO search_domains (search_id, journey_id, modifier_journey_name, journey_selection_text, journey_selection_description)
+SELECT search_id, 'b87a0636-654e-11ea-bc55-0242ac130003', 'hospitals', 'L&L hospital journey', 'Linen & Laundry hospital specific GM journey'
 FROM search_terms
 WHERE search_term = 'linen';
 
-INSERT INTO search_domains (search_id, journey_id)
-SELECT search_id, 'b87a0636-654e-11ea-bc55-0242ac130003'
+INSERT INTO search_domains (search_id, journey_id, modifier_journey_name, journey_selection_text, journey_selection_description)
+SELECT search_id, 'b87a0636-654e-11ea-bc55-0242ac130003', 'bedsheets', 'L&L bedsheets journey', 'Linen & Laundry bedsheets specific GM journey'
 FROM search_terms
 WHERE search_term = 'laundry services';
 
-INSERT INTO search_domains (search_id, journey_id)
-SELECT search_id, 'ccb5c730-75b5-11ea-bc55-0242ac130003'
+INSERT INTO search_domains (search_id, journey_id, modifier_journey_name, journey_selection_text, journey_selection_description)
+SELECT search_id, 'ccb5c730-75b5-11ea-bc55-0242ac130003', 'contracts', 'Legal Services contracts journey', 'WPS Legal Services contracts specific journey'
 FROM search_terms
 WHERE search_term = 'legal';
 
-INSERT INTO search_domains (search_id, journey_id)
-SELECT search_id, 'ccb6174e-75b5-11ea-bc55-0242ac130003'
+INSERT INTO search_domains (search_id, journey_id, modifier_journey_name, journey_selection_text, journey_selection_description)
+SELECT search_id, 'ccb6174e-75b5-11ea-bc55-0242ac130003', 'conveyancing', 'Legal Services conveyancing journey', 'WPS Legal Services conveyancing specific journey'
 FROM search_terms
 WHERE search_term = 'laptops';

--- a/guided-match/insert.sql
+++ b/guided-match/insert.sql
@@ -6,10 +6,10 @@ DELETE FROM search_domains;
 DELETE FROM search_terms;
 DELETE FROM journeys;
 
-INSERT INTO journeys (journey_id, journey_name)
-VALUES ('ccb5a43a-75b5-11ea-bc55-0242ac130003', 'Linen & Laundry'),
-('ccb5c730-75b5-11ea-bc55-0242ac130003', 'Wider Public Sector Legal Services'),
-('ccb6174e-75b5-11ea-bc55-0242ac130003', 'Tech & EduTech');
+INSERT INTO journeys (journey_id, journey_name, published)
+VALUES ('ccb5a43a-75b5-11ea-bc55-0242ac130003', 'Linen & Laundry', true),
+('ccb5c730-75b5-11ea-bc55-0242ac130003', 'Wider Public Sector Legal Services', true),
+('ccb6174e-75b5-11ea-bc55-0242ac130003', 'Tech & EduTech', true);
 
 INSERT INTO "search_terms" (search_term)
 VALUES ('linen'),('laundry services'),('legal'),('laptops');


### PR DESCRIPTION
As per the [GM API spec](https://github.com/Crown-Commercial-Service/ccs-scale-api-definitions/blob/master/guided-match/guided-match-service.yaml#L46), the `get-journey-summary` operation is supposed to be based on a UUID type value.  This change adds an auto-generated UUID column to the `search_domains` table to accommodate this.

Also thrown in a script I've been using to populate this table - thought it might be useful to include.