### PR TITLE
Feature/sfat 135 journey instance outcomes

### DIFF
--- a/guided-match/ddl.sql
+++ b/guided-match/ddl.sql
@@ -7,6 +7,7 @@ Description This file is a script to create the tables for the Find a Thing data
 
 */
 CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+CREATE TYPE enum_outcome_type AS ENUM ('support', 'agreement');
 
 CREATE TABLE journey_instance_answers (
   journey_instance_answer_id        BIGSERIAL PRIMARY KEY,
@@ -31,8 +32,6 @@ CREATE TABLE journey_instance_questions (
 );
 CREATE INDEX JOIQ_IDX1 on JOURNEY_INSTANCE_QUESTIONS (journey_question_id);
 
-CREATE TYPE enum_outcome_type AS ENUM ('support', 'agreement');
-
 CREATE TABLE journey_instances (
   journey_instance_id               BIGSERIAL PRIMARY KEY,
   journey_instance_uuid             UUID NOT NULL UNIQUE,
@@ -44,11 +43,11 @@ CREATE TABLE journey_instances (
 );
 CREATE INDEX JOIN_IDX1 ON JOURNEY_INSTANCES(journey_start_date);
 
-CREATE TABLE journey_instance_outcomes (
-  journey_instance_outcomes_id      BIGSERIAL PRIMARY KEY,
-  journey_instance_id               BIGINT NOT NULL,
-  agreement_number                  VARCHAR(20) NOT NULL,
-  lot_number                        VARCHAR(20) NOT NULL,
+CREATE TABLE journey_instance_outcome_details (
+  journey_instance_outcome_detail_id      BIGSERIAL PRIMARY KEY,
+  journey_instance_id                     BIGINT NOT NULL,
+  agreement_number                        VARCHAR(20) NOT NULL,
+  lot_number                              VARCHAR(20) NOT NULL,
   unique (journey_instance_id, agreement_number, lot_number)
 );
 
@@ -103,3 +102,7 @@ ADD CONSTRAINT journey_instance_answers_journey_instance_questions_fk FOREIGN KE
 ALTER TABLE journey_instances
 ADD CONSTRAINT journey_instances_journey_fk FOREIGN KEY (journey_id)
     REFERENCES journeys(journey_id);
+
+ALTER TABLE journey_instance_outcome_details
+ADD CONSTRAINT journey_instance_outcome_details_journey_instances_fk FOREIGN KEY (journey_instance_id)
+    REFERENCES journey_instances (journey_instance_id);

--- a/guided-match/ddl.sql
+++ b/guided-match/ddl.sql
@@ -31,6 +31,7 @@ CREATE TABLE journey_instance_questions (
 );
 CREATE INDEX JOIQ_IDX1 on JOURNEY_INSTANCE_QUESTIONS (journey_question_id);
 
+CREATE TYPE enum_outcome_type AS ENUM ('support', 'agreement');
 
 CREATE TABLE journey_instances (
   journey_instance_id               BIGSERIAL PRIMARY KEY,
@@ -38,9 +39,18 @@ CREATE TABLE journey_instances (
   journey_id                        UUID NOT NULL,
   original_search_term              VARCHAR(200) NOT NULL,
   journey_start_date                DATE NOT NULL,
-  journey_end_date                  DATE
+  journey_end_date                  DATE,
+  outcome_type                      enum_outcome_type
 );
 CREATE INDEX JOIN_IDX1 ON JOURNEY_INSTANCES(journey_start_date);
+
+CREATE TABLE journey_instance_outcomes (
+  journey_instance_outcomes_id      BIGSERIAL PRIMARY KEY,
+  journey_instance_id               BIGINT NOT NULL,
+  agreement_number                  VARCHAR(20) NOT NULL,
+  lot_number                        VARCHAR(20) NOT NULL,
+  unique (journey_instance_id, agreement_number, lot_number)
+);
 
 /* This table could exist in some form in both databases */
 CREATE TABLE journeys (

--- a/guided-match/drop_tables.sql
+++ b/guided-match/drop_tables.sql
@@ -6,17 +6,19 @@ Date        June 4th 2020
 
 Author      Trevor Cummings
 
-Description This file is a script to drop the tables for the Find a Thing database. 
+Description This file is a script to drop the tables for the Find a Thing database.
 */
 
-DROP TABLE journey_instance_answers;
+DROP TABLE IF EXISTS journey_instance_answers;
 
-DROP TABLE journey_instance_questions ;
+DROP TABLE IF EXISTS journey_instance_questions;
 
-DROP TABLE journey_instances ;
+DROP TABLE IF EXISTS journey_instance_outcomes;
 
-DROP TABLE search_domains ;
+DROP TABLE IF EXISTS journey_instances;
 
-DROP TABLE journeys ;
+DROP TABLE IF EXISTS search_domains;
 
-DROP TABLE search_terms ;
+DROP TABLE IF EXISTS journeys;
+
+DROP TABLE IF EXISTS search_terms;

--- a/guided-match/drop_tables.sql
+++ b/guided-match/drop_tables.sql
@@ -13,7 +13,7 @@ DROP TABLE IF EXISTS journey_instance_answers;
 
 DROP TABLE IF EXISTS journey_instance_questions;
 
-DROP TABLE IF EXISTS journey_instance_outcomes;
+DROP TABLE IF EXISTS journey_instance_outcome_details;
 
 DROP TABLE IF EXISTS journey_instances;
 
@@ -22,3 +22,5 @@ DROP TABLE IF EXISTS search_domains;
 DROP TABLE IF EXISTS journeys;
 
 DROP TABLE IF EXISTS search_terms;
+
+DROP TYPE IF EXISTS enum_outcome_type;


### PR DESCRIPTION
Pending confirmation from Rachel via Jaivik, these changes support persistence of final GM journey outcome details for each journey instance in the form of a collection of records identifying agreement/lot combination in `journey_instance_outcome_details`.