### PR TITLE
SFAT-7 - initial attempt at a shell script to provision a new DB

### DIFF
--- a/agreements/provision-agreements-database.sh
+++ b/agreements/provision-agreements-database.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Create and Populate an Agreements Database.
+# 
+# Prerequisites:
+#   - Create ~/.pgpass file to hold authentication details
+#     - *:*:*:sysadmin:PASSWORD
+#     - https://www.postgresql.org/docs/current/libpq-pgpass.html
+#   - An SSH tunnel has been established to the remote database via an EC2 bastion host, such that it appears as a local DB
+#     - Using a command similar to:
+#     - ssh -i  {ENV}-bastion-key.pem -L 5432:{RDS_ENDPOINT}:5432 ubuntu@{BASTION_EC2_IP}
+
+
+export SERVER=localhost
+export PORT=5432
+export DATABASE=agreements
+export USERNAME=sysadmin
+
+psql -h $SERVER -d $DATABASE -p $PORT -U $USERNAME -a -q -f ddl.sql
+
+psql -h $SERVER -d $DATABASE -p $PORT -U $USERNAME -a -q -f create_commercial_agreements.sql
+psql -h $SERVER -d $DATABASE -p $PORT -U $USERNAME -a -q -f create_lots.sql
+psql -h $SERVER -d $DATABASE -p $PORT -U $USERNAME -a -q -f create_sectors.sql
+psql -h $SERVER -d $DATABASE -p $PORT -U $USERNAME -a -q -f create_route_to_market.sql
+psql -h $SERVER -d $DATABASE -p $PORT -U $USERNAME -a -q -f create_lot_sectors.sql 
+psql -h $SERVER -d $DATABASE -p $PORT -U $USERNAME -a -q -f create_lot_route_to_market.sql


### PR DESCRIPTION
This is just a first stab at a script to automate setting up a new agreements database.

I used this to provision DEV.

As there are a few scripts that need to be run in a certain sequence - seemed like scripting it was a good idea. This is just a first attempt - plenty of room for improvement, but thought it may be useful given the number of environments we need to manage.