### PR TITLE
GM v0.0.3: Drop not null on question_hint

### DIFF
--- a/guided-match/versions/v0.0.3.sql
+++ b/guided-match/versions/v0.0.3.sql
@@ -1,0 +1,7 @@
+-- Version No   Version Description
+----------      -------------------
+-- v0.0.3       Make question_hint column in jiq table nullable
+
+-- Not all questions have hint text, so this column must be nullable
+ALTER TABLE journey_instance_questions
+ALTER COLUMN question_hint DROP NOT NULL;


### PR DESCRIPTION
This has come to light off the back of some recent content changes.. was seeing GM API errors as this constraint prevented a row being inserted for the opening tech question (which no-longer has hint text.)