### PR TITLE
Update v2 Tenders DB (document templates)

### DIFF
--- a/tenders-api/drop_tables.sql
+++ b/tenders-api/drop_tables.sql
@@ -14,3 +14,7 @@ DROP TABLE IF EXISTS procurement_projects;
 DROP TABLE IF EXISTS organisation_mapping;
 
 DROP TABLE IF EXISTS journeys;
+
+DROP TABLE IF EXISTS document_template_sources;
+
+DROP TABLE IF EXISTS document_templates;

--- a/tenders-api/update_v2.sql
+++ b/tenders-api/update_v2.sql
@@ -1,0 +1,20 @@
+/*
+Tenders DB Update script: v2 (Document templates and sources)
+*/
+CREATE TABLE IF NOT EXISTS document_templates (
+    document_template_id  SERIAL PRIMARY KEY,
+    template_url          VARCHAR(2048)  NOT NULL,
+    event_type            VARCHAR(32) NOT NULL);
+
+CREATE TABLE IF NOT EXISTS document_template_sources (
+    document_template_source_id   SERIAL PRIMARY KEY,
+    document_template_id          INTEGER NOT NULL,
+    field_placeholder             VARCHAR(512) NOT NULL,
+    source_type                   VARCHAR(32) NOT NULL,
+    source_path                   VARCHAR(2048) NOT NULL,
+    target_type                   VARCHAR(32) NOT NULL,
+
+    -- Constraints
+    CONSTRAINT document_templates_fk FOREIGN KEY(document_template_id) REFERENCES document_templates(document_template_id),
+    CONSTRAINT check_source_type CHECK (source_type IN ('JSON', 'JAVA', 'SQL')),
+    CONSTRAINT check_target_type CHECK (target_type IN ('SIMPLE', 'LIST', 'TABLE')));

--- a/tenders-api/update_v2.sql
+++ b/tenders-api/update_v2.sql
@@ -17,4 +17,4 @@ CREATE TABLE IF NOT EXISTS document_template_sources (
     -- Constraints
     CONSTRAINT document_templates_fk FOREIGN KEY(document_template_id) REFERENCES document_templates(document_template_id),
     CONSTRAINT check_source_type CHECK (source_type IN ('JSON', 'JAVA', 'SQL')),
-    CONSTRAINT check_target_type CHECK (target_type IN ('SIMPLE', 'LIST', 'TABLE')));
+    CONSTRAINT check_target_type CHECK (target_type IN ('SIMPLE', 'LIST', 'TABLE', 'DATETIME')));


### PR DESCRIPTION
As outlined in plan on SCAT-3027 (see comments).  This is only in place on SBX2 at the moment with a few field mappings (one of each type) but gives us what we need I think.