### PR TITLE
Add assessment_id to proc event table

### DIFF
--- a/tenders-api/update_v3.sql
+++ b/tenders-api/update_v3.sql
@@ -2,3 +2,4 @@
 Tenders DB Update script: v3: Add assessment supplier target (numeric) to proc events
 */
 ALTER TABLE procurement_events ADD COLUMN IF NOT EXISTS assessment_supplier_target INTEGER NULL;
+ALTER TABLE procurement_events ADD COLUMN IF NOT EXISTS assessment_id INTEGER NULL;


### PR DESCRIPTION
No FK as schemas are supposed to be separate - but comments on SCAT-3501 imply this is required.  Updating v3 script as nothing is deployed beyond SBX yet.