### PR TITLE
Add unique constraint on buyer_user_details user_id

### DIFF
--- a/tenders-api/provision-tenders-api-database-gpaas.sh
+++ b/tenders-api/provision-tenders-api-database-gpaas.sh
@@ -29,6 +29,7 @@ declare -a FILES_ARRAY=(\
     "update_v12.sql" \
     "update_v13.sql" \
     "update_v14.sql" \
+    "update_v15.sql" \
 )
 
 for i in ${FILES_ARRAY[@]}; do cat $i >> .combined.sql;done

--- a/tenders-api/provision-tenders-api-database.sh
+++ b/tenders-api/provision-tenders-api-database.sh
@@ -36,4 +36,5 @@ psql -h $SERVER -d $DATABASE -p $PORT -U $USERNAME -a -q -f udpate_v11.sql
 psql -h $SERVER -d $DATABASE -p $PORT -U $USERNAME -a -q -f udpate_v12.sql
 psql -h $SERVER -d $DATABASE -p $PORT -U $USERNAME -a -q -f udpate_v13.sql
 psql -h $SERVER -d $DATABASE -p $PORT -U $USERNAME -a -q -f udpate_v14.sql
+psql -h $SERVER -d $DATABASE -p $PORT -U $USERNAME -a -q -f udpate_v15.sql
 

--- a/tenders-api/update_v15.sql
+++ b/tenders-api/update_v15.sql
@@ -1,0 +1,6 @@
+
+/*
+Tenders DB Update script: v15 - Buyer user details unique constraint on user_id
+*/
+
+ALTER TABLE buyer_user_details ADD CONSTRAINT buyer_user_unique UNIQUE(user_id);


### PR DESCRIPTION
There will be accompanying changes to RPA export scheduler to lock on rows in `buyer_user_details` to prevent multiple scheduler instances attempting to write duplicate records for export to the table - but this should prevent it happening as fall-back.