### PR TITLE
alter sql to increase column length

### DIFF
--- a/agreements-service/patches/20221215_8205.sql
+++ b/agreements-service/patches/20221215_8205.sql
@@ -1,0 +1,5 @@
+/*
+Contact point name length increased to match the DMP API schema.
+https://crowncommercialservice.atlassian.net/browse/SCAT-8205
+*/
+ALTER TABLE contact_point_lot_ors ALTER COLUMN contact_point_name TYPE varchar(255) USING contact_point_name::varchar;


### PR DESCRIPTION
To match the DMP API contact name, the column size increased to 255.

https://crowncommercialservice.atlassian.net/browse/SCAT-8205