### PR TITLE
Remove lines referencing guided match scripts from the local setup script

### DIFF
--- a/local_setup.sh
+++ b/local_setup.sh
@@ -4,17 +4,6 @@
 
 source env_setting.sh
 
-psql -h $SERVER -d $DATABASE -p $PORT -U $USERNAME -a -q -c "set schema '$SCHEMA'" -f guided-match/reset_setup/drop_tables.sql
-
-psql -h $SERVER -d $DATABASE -p $PORT -U $USERNAME -a -q -c "set schema '$SCHEMA'" -f guided-match/core_structure/create_tables.sql
-
-psql -h $SERVER -d $DATABASE -p $PORT -U $USERNAME -a -q -c "set schema '$SCHEMA'" -f guided-match/core_structure/apply_constraints.sql
-
-cd guided-match/patches
-for FILE in *; do psql -h $SERVER -d $DATABASE -p $PORT -U $USERNAME -a -q -c "set schema '$SCHEMA'" -f $FILE; done
-
-cd ../../
-
 psql -h $SERVER -d $DATABASE -p $PORT -U $USERNAME -a -q -c "set schema '$SCHEMA'" -f agreements-service/reset_setup/drop_tables.sql
 
 psql -h $SERVER -d $DATABASE -p $PORT -U $USERNAME -a -q -c "set schema '$SCHEMA'" -f agreements-service/core_structure/create_tables.sql

--- a/tenders-api/202209290_6047.sql
+++ b/tenders-api/202209290_6047.sql
@@ -1,1 +1,0 @@
-ALTER TABLE procurement_events ADD template_id int4 NULL;


### PR DESCRIPTION
In the dev setup script, I’ve removed the lines which were specific to the agreements service.

I’ve also removed an update to the tenders API as it is already (and should have been) in the tenders API repo (see https://github.com/Crown-Commercial-Service/ccs-scale-tenders-db-scripts/pull/5).